### PR TITLE
Add support for kustomize_output_file param

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Kustomize GitHub Actions is a single GitHub Action that can be executed on diffe
 An exit code of `0` is considered a successful execution.
 
 ## Usage
-The most common usage is to run `kustomize build` on an overlays directory, where one overlays directory represents k8s configs for one environment. A comment will be posted to the pull request depending on the output of the Kustomize build command being executed. This workflow can be configured by adding the following content to the GitHub Actions workflow YAML file. 
+The most common usage is to run `kustomize build` on an overlays directory, where one overlays directory represents k8s configs for one environment. A comment will be posted to the pull request depending on the output of the Kustomize build command being executed. This workflow can be configured by adding the following content to the GitHub Actions workflow YAML file.
 ```yaml
 name: 'Kustomize GitHub Actions'
 on:
@@ -28,10 +28,11 @@ jobs:
           kustomize_version: '3.0.0'
           kustomize_build_dir: '.'
           kustomize_comment: true
+          kustomize_build_output: "gitops/rendered.yaml"
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
 ```
-This was a simplified example showing the basic features of these Kustomize rraform GitHub Actions. More examples, coming soon!
+This was a simplified example showing the basic features of these Kustomize GitHub Action. More examples, coming soon!
 
 # Inputs
 
@@ -40,7 +41,7 @@ Inputs configure Kustomize GitHub Actions to perform build action.
 * `kustomize_version` - (Required) The Kustomize version to use for `kustomize build`.
 * `kustomize_build_dir` - (Optional) The directory to run `kustomize build` on (assumes that the directory contains a kustomization yaml file). Defaults to `.`.
 * `kustomize_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `false`.
-
+* `kustomize_output_file` - (Optional) Path to to file to write the kustomize build output t.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: '0'
   kustomize_output_file:
-    description: 'Path to to file to write the kustomize build output to'
+    description: 'Path to file to write the kustomize build output to'
     required: false
     default: ''
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Comment kustomize output'
     required: false
     default: '0'
+  kustomize_output_file:
+    description: 'Path to to file to write the kustomize build output to'
+    required: false
+    default: ''
 outputs:
   kustomize_build_output:
     description: 'Output of kustomize build'

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -19,6 +19,11 @@ function parse_inputs {
     if [ "${INPUT_KUSTOMIZE_COMMENT}" == "1" ] || [ "${INPUT_KUSTOMIZE_COMMENT}" == "true" ]; then
         kustomize_comment=1
     fi
+
+    kustomize_output_file=""
+    if [ -n "${INPUT_KUSTOMIZE_OUTPUT_FILE}" ]; then
+      kustomize_output_file=${INPUT_KUSTOMIZE_OUTPUT_FILE}
+    fi
 }
 
 function install_kustomize {
@@ -31,7 +36,7 @@ function install_kustomize {
         exit 1
     fi
     echo "Successfully downloaded kustomize v${kustomize_version}."
-    
+
     echo "Allowing execute privilege to kustomize."
     chmod +x /usr/bin/kustomize
     if [ "${?}" -ne 0 ]; then
@@ -50,7 +55,7 @@ function main {
 
     install_kustomize
     kustomize_build
-    
+
 }
 
 main "${*}"

--- a/src/kustomize_build.sh
+++ b/src/kustomize_build.sh
@@ -4,13 +4,13 @@ function kustomize_build {
     # gather output
     echo "build: info: kustomize build in directory ${kustomize_build_dir}."
     build_output=$(kustomize build ${kustomize_build_dir} 2>&1)
+
     build_exit_code=${?}
-    
 
     # exit code 0 - success
     if [ ${build_exit_code} -eq 0 ];then
         build_comment_status="Success"
-        echo "build: info: successfully executed kustomzie build in ${kustomize_build_dir}."
+        echo "build: info: successfully executed kustomize build in ${kustomize_build_dir}."
         echo "${build_output}"
         echo
     fi
@@ -21,6 +21,14 @@ function kustomize_build {
         echo "build: error: failed to execute kustomize build in ${kustomize_build_dir}."
         echo "${build_output}"
         echo
+    fi
+
+    # write output to file
+    if [ -n ${kustomize_output_file} ]; then
+      echo "build: writing output to ${kustomize_output_file}"
+      cat > "${kustomize_output_file}" <<EOF
+${build_output}
+EOF
     fi
 
     # comment
@@ -34,7 +42,7 @@ ${build_output}
 </details>
 
 *Workflow: \`${GITHUB_WORKFLOW}\`, Action: \`${GITHUB_ACTION}\`, Build Directory: \`${kustomize_build_dir}\`*"
-    
+
         echo "build: info: creating json"
         build_payload=$(echo "${build_comment_wrapper}" | jq -R --slurp '{body: .}')
         build_comment_url=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)


### PR DESCRIPTION
This adds a new parameter (as proposed in #9) to optionally write the output file to the filesystem, in addition to returning it as an output.