### PR TITLE
Add page iterator for future-proofing downloads

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -38,11 +38,14 @@ function parse_inputs {
 
 function install_kustomize {
 
-    # hack to support older version
-    url=$(curl -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=1" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64")) | .browser_download_url')
-    if [ -z "${url}" ]; then
-        url=$(curl -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=2" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64")) | .browser_download_url')
-    fi
+    echo "getting download url for kustomize ${kustomize_version}"
+    for i in {1..100}; do
+        url=$(curl -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=$i" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64"))  | .browser_download_url')
+        if [ ! -z $url ]; then 
+           echo "Download URL found in $url"
+           break
+        fi
+    done
 
     echo "Downloading kustomize v${kustomize_version}"
     if [[ "${url}" =~ .tar.gz$ ]]; then


### PR DESCRIPTION
**Details of Change**
<!--- add details of what this pull request adds/changes-->

Use page iterator to fetch releases from github api to future-proof downloads.

**Issue**
<!--- Is there any issue(bug/feature request) already open for this case? If yes, please link it.-->

At the time of writing, page 2 of the release has 55 items already (55% to page 3):

```
$ curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=2 | jq '. | length'
55
```

**Test Results**
<!--- Please explain how did you test it? Attach links/screenshots if needed.-->

Small test of the block:

```
$ bash test.sh 1.0.1
getting download url for kustomize 1.0.1...
page 1
page 2
Download URL found in https://github.com/kubernetes-sigs/kustomize/releases/download/v1.0.1/kustomize_1.0.1_linux_amd64

$ bash test.sh 3.6.1
getting download url for kustomize 3.6.1...
page 1
page 2
Download URL found in https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.6.1/kustomize_v3.6.1_linux_amd64.tar.gz

$ bash test.sh 4.0.1
getting download url for kustomize 4.0.1...
page 1
Download URL found in https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.0.1/kustomize_v4.0.1_linux_amd64.tar.gz
```