### PR TITLE
fix: handle non provided kustomize_output_file

### DIFF
--- a/src/kustomize_build.sh
+++ b/src/kustomize_build.sh
@@ -25,7 +25,7 @@ function kustomize_build {
     fi
 
     # write output to file
-    if [ -n ${kustomize_output_file} ]; then
+    if [ -n "${kustomize_output_file}" ]; then
       echo "build: writing output to ${kustomize_output_file}"
       cat > "${kustomize_output_file}" <<EOF
 ${build_output}


### PR DESCRIPTION
without quotes, the statement is evaluated as true

**Details of Change**
<!--- add details of what this pull request adds/changes-->

Surround variable with quotes

**Issue**
<!--- Is there any issue(bug/feature request) already open for this case? If yes, please link it.-->

`kustomize_output_file` is optional, not providing it results in a failing job

**Test Results**
<!--- Please explain how did you test it? Attach links/screenshots if needed.-->

I created this script (it replicates the current implementation) and added quotes

```bash
kustomize_output_file=""
if [ -n "${INPUT_KUSTOMIZE_OUTPUT_FILE}" ]; then
  kustomize_output_file=${INPUT_KUSTOMIZE_OUTPUT_FILE}
fi

echo $kustomize_output_file

if [ -n "${kustomize_output_file}" ]; then
  echo "build: writing output to ${kustomize_output_file}"
fi

```

```bash
INPUT_KUSTOMIZE_OUTPUT_FILE="ok" sh script.sh
ok
build: writing output to ok
```

```bash
sh script.sh
```
