### PR TITLE
Use explicit download URL

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -37,22 +37,11 @@ function parse_inputs {
 }
 
 function install_kustomize {
+    url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${kustomize_version}/kustomize_v${kustomize_version}_darwin_amd64.tar.gz"
 
-    echo "getting download url for kustomize ${kustomize_version}"
-    for i in {1..100}; do
-        url=$(curl -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=$i" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64"))  | .browser_download_url')
-        if [ ! -z $url ]; then 
-           echo "Download URL found in $url"
-           break
-        fi
-    done
+    echo "Downloading kustomize v${kustomize_version} from $url"
+    curl -s -S -L ${url} | tar -xz -C /usr/bin
 
-    echo "Downloading kustomize v${kustomize_version}"
-    if [[ "${url}" =~ .tar.gz$ ]]; then
-      curl -s -S -L ${url} | tar -xz -C /usr/bin
-    else
-      curl -s -S -L ${url} -o /usr/bin/kustomize
-    fi
     if [ "${?}" -ne 0 ]; then
         echo "Failed to download kustomize v${kustomize_version}."
         exit 1


### PR DESCRIPTION
Download URLs follow an explicit pattern that can be utilized to deduce the correct URL from the provided version only, therefore there seem to be no reason to use pagination and field matching to find the correct URL.

Pagination introduces unnecessary complexity and, even worse, it can cause throttling by the server when multiple workflow branches are executed in parallel.