### PR TITLE
Make downloading of kustomize more robust to GitHub API rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ This was a simplified example showing the basic features of these Kustomize GitH
 Inputs configure Kustomize GitHub Actions to perform build action.
 
 * `kustomize_version` - (Required) The Kustomize version to use for `kustomize build`.
+* `kustomize_install` - (Optional) Whether or not to install kustomize.
 * `kustomize_build_dir` - (Optional) The directory to run `kustomize build` on (assumes that the directory contains a kustomization yaml file). Defaults to `.`.
 * `kustomize_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `false`.
-* `kustomize_output_file` - (Optional) Path to to file to write the kustomize build output t.
+* `kustomize_output_file` - (Optional) Path to to file to write the kustomize build output to.
 * `kustomize_build_options` - (Optional) Provide build options to kustomize build.
 * `enable_alpha_plugins` - (Optional) Enable Kustomize plugins. Defaults to `false`.
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
     description: 'Kustomize version'
     required: true
     default: '3.0.0'
+  kustomize_install:
+    required: false
+    default: '1'
   kustomize_build_dir:
     description: 'Directory to do kustomize build on'
     required: false

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -20,6 +20,11 @@ function parse_inputs {
         kustomize_comment=1
     fi
 
+    kustomize_install=1
+    if [ "${INPUT_KUSTOMIZE_INSTALL}" == "0" ] || [ "${INPUT_KUSTOMIZE_INSTALL}" == "false" ]; then
+        kustomize_install=0
+    fi
+
     kustomize_output_file=""
     if [ -n "${INPUT_KUSTOMIZE_OUTPUT_FILE}" ]; then
       kustomize_output_file=${INPUT_KUSTOMIZE_OUTPUT_FILE}
@@ -39,19 +44,21 @@ function parse_inputs {
 function install_kustomize {
 
     echo "getting download url for kustomize ${kustomize_version}"
-    for i in {1..100}; do
-        url=$(curl -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=$i" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64"))  | .browser_download_url')
-        if [ ! -z $url ]; then 
-           echo "Download URL found in $url"
-           break
-        fi
-    done
+
+    url=$(curl --retry-all-errors --fail --retry 30 --retry-max-time 120 -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=$i" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64"))  | .browser_download_url')
+
+    if [ ! -z $url ]; then
+       echo "Download URL found in $url"
+    else
+      echo "Failed to find download URL for ${kustomize_version}"
+      exit 1
+    fi
 
     echo "Downloading kustomize v${kustomize_version}"
     if [[ "${url}" =~ .tar.gz$ ]]; then
-      curl -s -S -L ${url} | tar -xz -C /usr/bin
+      curl --retry 30 --retry-max-time 120 -s -S -L ${url} | tar -xz -C /usr/bin
     else
-      curl -s -S -L ${url} -o /usr/bin/kustomize
+      curl --retry 30 --retry-max-time 120 -s -S -L ${url} -o /usr/bin/kustomize
     fi
     if [ "${?}" -ne 0 ]; then
         echo "Failed to download kustomize v${kustomize_version}."
@@ -75,7 +82,10 @@ function main {
     source ${scriptDir}/kustomize_build.sh
     parse_inputs
 
-    install_kustomize
+    if  [ "${kustomize_install}" == "1" ]; then
+      install_kustomize
+    fi
+
     kustomize_build
 
 }

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -45,10 +45,15 @@ function install_kustomize {
 
     echo "getting download url for kustomize ${kustomize_version}"
 
-    url=$(curl --retry-all-errors --fail --retry 30 --retry-max-time 120 -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=$i" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64"))  | .browser_download_url')
+    for i in {1..100}; do
+      url=$(curl --retry-all-errors --fail --retry 30 --retry-max-time 120 -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=$i" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64"))  | .browser_download_url')
+      if [ ! -z $url ]; then
+        break
+      fi
+    done
 
     if [ ! -z $url ]; then
-       echo "Download URL found in $url"
+      echo "Download URL found in $url"
     else
       echo "Failed to find download URL for ${kustomize_version}"
       exit 1


### PR DESCRIPTION
Also, introduce `kustomize_install` as a boolean option that can disable
installing kustomize alltogether, assuming you install it some other way,
like with https://github.com/yokawasa/action-setup-kube-tools

**Details of Change**
<!--- add details of what this pull request adds/changes-->

**Issue**
<!--- Is there any issue(bug/feature request) already open for this case? If yes, please link it.-->
Fixes #35

**Test Results**
<!--- Please explain how did you test it? Attach links/screenshots if needed.-->
