### PR TITLE
try adding auth to avoid errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ inputs:
     required: true
     default: '3.0.0'
   kustomize_install:
+    description: "Unknown"
     required: false
     default: '1'
   kustomize_build_dir:
@@ -33,6 +34,10 @@ inputs:
     description: 'Enable Kustomize plugins'
     required: false
     default: '0'
+  token:
+    description: 'GitHub Token for Authentication to Github API (mainly for limit avoidance)'
+    required: false
+    default: ''
 outputs:
   kustomize_build_output:
     description: 'Output of kustomize build'

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -36,8 +36,13 @@ function parse_inputs {
     fi
 
     enable_alpha_plugins=""
-   if [ "${INPUT_ENABLE_ALPHA_PLUGINS}" == "1" ] || [ "${INPUT_ENABLE_ALPHA_PLUGINS}" == "true" ]; then
+    if [ "${INPUT_ENABLE_ALPHA_PLUGINS}" == "1" ] || [ "${INPUT_ENABLE_ALPHA_PLUGINS}" == "true" ]; then
        enable_alpha_plugins="--enable_alpha_plugins"
+    fi
+
+    with_token=""
+    if [ "${INPUT_TOKEN}" != "" ]; then
+       with_token=(-H "Authorization: token ${INPUT_TOKEN}")
     fi
 }
 
@@ -46,7 +51,7 @@ function install_kustomize {
     echo "getting download url for kustomize ${kustomize_version}"
 
     for i in {1..100}; do
-      url=$(curl --retry-all-errors --fail --retry 30 --retry-max-time 120 -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=$i" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64"))  | .browser_download_url')
+      url=$(curl --retry-all-errors --fail --retry 30 --retry-max-time 120 "${with_token[@]}" -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100&page=$i" | jq -r '.[].assets[] | select(.browser_download_url | test("kustomize(_|.)?(v)?'$kustomize_version'_linux_amd64"))  | .browser_download_url')
       if [ ! -z $url ]; then
         break
       fi


### PR DESCRIPTION
Recently this action has been getting "stuck" in local tests it gets stuck when API limits are hit and 403 is hit. Adding a token input allows you to auth against the GitHub API to bypass limits. 

For whatever reason it seems like the limits are being hit more and more, possibly due to shared runners or an internal change, not sure, but this appears to fix it for me.

**Details of Change**
- adds authentication (optional)

**Issue**
- https://github.com/karancode/kustomize-github-action/issues/38