### PR TITLE
Changing set-output to GITHUB_OUTPUT

### DIFF
--- a/src/kustomize_build.sh
+++ b/src/kustomize_build.sh
@@ -56,6 +56,6 @@ ${build_output}
         echo "${build_payload}" | curl -s -S -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" --header "Content-Type: application/json" --data @- "${build_comment_url}" > /dev/null
     fi
 
-    echo ::set-output name=kustomize_build_output::${build_output}
+    echo kustomize_build_output=${build_output} >> $GITHUB_OUTPUT
     exit ${build_exit_code}
 }


### PR DESCRIPTION
GitHub will stop supporting set output in May 2023

**Details of Change**
Changing set-output to github_output

**Issue**
The `set-output` command is deprecated and will be disabled soon (May 2023)

**Test Results**
<!--- Please explain how did you test it? Attach links/screenshots if needed.-->
