### PR TITLE
Ensure that curl works in no token is set

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -40,7 +40,7 @@ function parse_inputs {
        enable_alpha_plugins="--enable_alpha_plugins"
     fi
 
-    with_token=""
+    with_token=()
     if [ "${INPUT_TOKEN}" != "" ]; then
        with_token=(-H "Authorization: token ${INPUT_TOKEN}")
     fi


### PR DESCRIPTION
**Details of Change**
Update `with_token` so that curl downloads kustomize if a token isn't set

**Issue**
#46

**Test Results**
Tested a kustomize github action using my branch and it worked as expected.
